### PR TITLE
feat(command): add version command

### DIFF
--- a/lib/helpers/executor.js
+++ b/lib/helpers/executor.js
@@ -4,8 +4,9 @@ function executor (object) {
   switch (object.command) {
     case 'sha':
       return sha(object.payload)
-    case 'undefined':
     case 'help':
+    case 'undefined':
+    case 'version':
       return object.payload
     default:
       throw new Error("command doesn't exist")

--- a/lib/helpers/parser.js
+++ b/lib/helpers/parser.js
@@ -1,4 +1,4 @@
-const { helpMessage, commandNotFoundMessage } = require('./shared')
+const { helpMessage, commandNotFoundMessage, versionMessage } = require('./shared')
 
 function parser (args) {
   const action = args[2]
@@ -7,6 +7,9 @@ function parser (args) {
     case '-s':
     case '--sha':
       return { command: 'sha', payload: args[3] }
+    case '-v':
+    case '--version':
+      return { command: 'version', payload: versionMessage() }
     case '-h':
     case '--help':
       return { command: 'help', payload: helpMessage() }

--- a/lib/helpers/shared.js
+++ b/lib/helpers/shared.js
@@ -1,7 +1,3 @@
-function pathIsRequiredMessage () {
-  return 'path is required'
-}
-
 function commandNotFoundMessage () {
   return `
     Command Not Found, Verify Available Commands Running:
@@ -23,8 +19,24 @@ function helpMessage () {
   `
 }
 
+function pathIsRequiredMessage () {
+  return 'path is required'
+}
+
+function pkgInfo () {
+  const file = require('../../package.json')
+
+  return file
+}
+
+function versionMessage () {
+  return `v${pkgInfo().version}`
+}
+
 module.exports = {
   commandNotFoundMessage,
   helpMessage,
-  pathIsRequiredMessage
+  pathIsRequiredMessage,
+  pkgInfo,
+  versionMessage
 }

--- a/test/helpers/shared.spec.js
+++ b/test/helpers/shared.spec.js
@@ -1,7 +1,8 @@
 const {
   commandNotFoundMessage,
   helpMessage,
-  pathIsRequiredMessage
+  pathIsRequiredMessage,
+  versionMessage
 } = require('../../lib/helpers/shared')
 
 describe('commandNotFoundMessage', () => {
@@ -36,5 +37,13 @@ describe('helpMessage', () => {
 describe('pathIsRequiredMessage', () => {
   it('returns a message', () => {
     expect(pathIsRequiredMessage()).toEqual('path is required')
+  })
+})
+
+describe('versionMessage', () => {
+  it('returns the package.json version', () => {
+    const file = require('../../package.json')
+
+    expect(versionMessage()).toEqual(`v${file.version}`)
   })
 })


### PR DESCRIPTION
add version flag, now we can use it like so `liondocs -v` or `liondocs --verson`

fix #30
